### PR TITLE
Use virtualized items repeater in Avalonia sample

### DIFF
--- a/Test1.Avalonia/MainWindow.axaml.cs
+++ b/Test1.Avalonia/MainWindow.axaml.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Linq;
 
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media.Imaging;
 using Avalonia.Media;
-using Avalonia;
 
 namespace Test1.Avalonia
 {
@@ -15,41 +18,42 @@ namespace Test1.Avalonia
             InitializeComponent();
 
             var scrollViewer = new ScrollViewer();
-            this.Content = scrollViewer;
+            Content = scrollViewer;
 
-            var panel = new StackPanel();
-            scrollViewer.Content = panel;
+            var itemsRepeater = new ItemsRepeater();
+            scrollViewer.Content = itemsRepeater;
 
             var source = new Bitmap(AppDomain.CurrentDomain.BaseDirectory + "test.png");
 
-
-            for (int i = 0; i < 10000; i++)
+            itemsRepeater.Items = Enumerable.Range(0, 10000);
+            itemsRepeater.ItemTemplate = new FuncDataTemplate<int>((item, _) => new Button
             {
-                var button = new Button();
-                button.Margin = new Thickness(0, 0, 0, 8);
-                button.HorizontalAlignment = HorizontalAlignment.Center;
+                Margin = new Thickness(0, 0, 0, 8),
+                HorizontalAlignment = HorizontalAlignment.Center,
 
-                var buttonStack = new StackPanel();
-                button.Content = buttonStack;
-
-                var label1 = new Label();
-                label1.HorizontalAlignment = HorizontalAlignment.Right;
-                label1.Content = "Top " + i.ToString();
-                buttonStack.Children.Add(label1);
-
-                var image1 = new Image();
-                image1.Source = source;
-                image1.Stretch = Stretch.None;
-                image1.HorizontalAlignment = HorizontalAlignment.Stretch;
-                buttonStack.Children.Add(image1);
-
-                var label2 = new Label();
-                label2.HorizontalAlignment = HorizontalAlignment.Left;
-                label2.Content = "Bottom " + i.ToString();
-                buttonStack.Children.Add(label2);
-
-                panel.Children.Add(button);
-            }
+                Content = new StackPanel
+                {
+                    Children =
+                    {
+                        new Label
+                        {
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            [!ContentProperty] = new Binding(".") { StringFormat = "Top {0}" }
+                        },
+                        new Image
+                        {
+                            Source = source,
+                            Stretch = Stretch.None,
+                            HorizontalAlignment = HorizontalAlignment.Stretch
+                        },
+                        new Label
+                        {
+                            HorizontalAlignment = HorizontalAlignment.Left,
+                            [!ContentProperty] = new Binding(".") { StringFormat = "Bottom {0}" }
+                        }
+                    }
+                }
+            });
         }
     }
 }

--- a/Test2.Avalonia/MainWindow.axaml.cs
+++ b/Test2.Avalonia/MainWindow.axaml.cs
@@ -1,46 +1,41 @@
 using System;
-
-using Avalonia.Controls;
-using Avalonia.Media.Imaging;
-using Avalonia.Media;
-using Avalonia.Threading;
-using System.Diagnostics;
-using System.Threading;
 using System.IO;
 using System.Linq;
+
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Media.Imaging;
+using Avalonia.Media;
+using Avalonia.Layout;
 
 namespace Test2.Avalonia
 {
     public partial class MainWindow : Window
     {
-        private Bitmap source;
         public MainWindow()
         {
             InitializeComponent();
 
-            var viewer = new ScrollViewer();
-            Content = viewer;
+            var scrollViewer = new ScrollViewer();
+            Content = scrollViewer;
 
-            var panel = new WrapPanel();
-            viewer.Content = panel;
-
-            var list = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory + "png-256", "*.png").Select(file => new Bitmap(file)).ToList();
-
-            for (int i = 0; i < 100; i++)
+            var itemsRepeater = new ItemsRepeater()
             {
-                list.ForEach(source =>
-                {
-                    var image = new Image();
-                    image.Source = source;
-                    image.Stretch = Stretch.Uniform;
-                    image.Width = 128;
-                    image.Height = 128;
-                    panel.Children.Add(image);
-                });
-            }
+                Layout = new WrapLayout()
+            };
+            scrollViewer.Content = itemsRepeater;
 
+            itemsRepeater.Items = Enumerable.Range(0, 100).SelectMany(_ =>
+                Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory + "png-256", "*.png").Select(file => new Bitmap(file))).ToArray();
+
+            itemsRepeater.ItemTemplate = new FuncDataTemplate<Bitmap>((source, _) => new Image
+            {
+                [!Image.SourceProperty] = new Binding("."),
+                Stretch = Stretch.Uniform,
+                Width = 128,
+                Height = 128
+            });
         }
-
-        
     }
 }

--- a/Test2.Avalonia/MainWindow.axaml.cs
+++ b/Test2.Avalonia/MainWindow.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Data;
 using Avalonia.Media.Imaging;
 using Avalonia.Media;
 using Avalonia.Layout;
+using System.Collections.Generic;
 
 namespace Test2.Avalonia
 {
@@ -26,8 +27,16 @@ namespace Test2.Avalonia
             };
             scrollViewer.Content = itemsRepeater;
 
-            itemsRepeater.Items = Enumerable.Range(0, 100).SelectMany(_ =>
-                Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory + "png-256", "*.png").Select(file => new Bitmap(file))).ToArray();
+            var images = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory + "png-256", "*.png").Select(file => new Bitmap(file)).ToArray();
+            var source = new List<Bitmap>(images.Length * 1000);
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (var image in images)
+                {
+                    source.Add(image);
+                }
+            }
+            itemsRepeater.Items = source;
 
             itemsRepeater.ItemTemplate = new FuncDataTemplate<Bitmap>((source, _) => new Image
             {


### PR DESCRIPTION
Hi! Interesting framework.
It seems there is a major difference "immediate vs retained" GUI frameworks, where LX is the first and Avalonia/WPF are the second type.

Specifically with Avalonia though, it's not optimal to add 10000 buttons to the StackPanel which doesn't have virtualization.
The best solution would be to replace StackPanel with `new ItemsPresenter { ItemsPanel = StackPanel }`. Or alternatively with ItemsRepeater, another built-in control with different virtualization implementation ported from UWP. 
In this PR I've chosen second one, mostly because it supports WrapLayout virtualization.
As a result, it shows way better results. There still memory issue on resizing, but that's another issue in our GPU rendering and Skia.
There is no built-in way to improve Test #3 though as far as I know. Something like AvalonEdit would work greatly with text selection for both WPF and Avalonia, but that's a third-party package.

With WPF, on other hand, same approach with ItemsPresenter/ItemsControl can be used to speed-up layouting noticeably. WPF already does a decent job to virtualize simple StackPanel without any special controls, but I believe it can be better. Unfortunately, I don't know easy way to create DataTemplate in the code behind without using XAML (not sure if it was a goal or these tests or not).
So, I haven't changed it, but to be kept in mind. Additionally, some minor changes like creating windows of the same size would make it more fair as well.